### PR TITLE
removing none existant composer.lock does continue with further comma…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,8 +99,8 @@ before_script:
   - mkdir -p tests/build/logs
 
 script:
-  - if [[ $DBAL_PROVIDER == 'container-interop-doctrine' ]]; then git checkout HEAD composer.json && rm -Rf vendor && rm composer.lock; composer require dasprid/container-interop-doctrine:^1.1 --prefer-source $DEPENDENCIES; cp tests/TestConfigurationContainerInteropDoctrine.php.dist tests/TestConfiguration.php.dist; fi
-  - if [[ $DBAL_PROVIDER == 'doctrine-orm-module' ]]; then git checkout HEAD composer.json && rm -Rf vendor && rm composer.lock; composer require doctrine/doctrine-orm-module:"~0.7||^1.0||^2.1" --prefer-source $DEPENDENCIES; cp tests/TestConfigurationDoctrineORMModule.php.dist tests/TestConfiguration.php.dist; fi
+  - if [[ $DBAL_PROVIDER == 'container-interop-doctrine' ]]; then git checkout HEAD composer.json && rm -Rf vendor && rm -f composer.lock; composer require dasprid/container-interop-doctrine:^1.1 --prefer-source $DEPENDENCIES; cp tests/TestConfigurationContainerInteropDoctrine.php.dist tests/TestConfiguration.php.dist; fi
+  - if [[ $DBAL_PROVIDER == 'doctrine-orm-module' ]]; then git checkout HEAD composer.json && rm -Rf vendor && rm -f composer.lock; composer require doctrine/doctrine-orm-module:"~0.7||^1.0||^2.1" --prefer-source $DEPENDENCIES; cp tests/TestConfigurationDoctrineORMModule.php.dist tests/TestConfiguration.php.dist; fi
   - if [[ $TEST_COVERAGE == 'true' ]]; then php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml --configuration ./phpunit.xml.dist; else ./vendor/bin/phpunit --configuration ./phpunit.xml.dist; fi
   - if [[ $EXECUTE_CS_CHECK == 'true' ]]; then ./vendor/bin/phpcs --standard=PSR2 src; fi
 


### PR DESCRIPTION
minor but this protects against `rm: cannot remove ‘composer.lock’: No such file or directory`